### PR TITLE
fix(cnk-29): static fields transpilation fix

### DIFF
--- a/libs/cli/src/commands/TranspileCommand/fn/_tests/test-static/src/index.ts
+++ b/libs/cli/src/commands/TranspileCommand/fn/_tests/test-static/src/index.ts
@@ -1,0 +1,18 @@
+class A {
+    static staticField = 'staticField';
+    constructor() {
+        const someVar = 1;
+    }
+}
+
+class B extends A {
+    constructor(
+    ) {
+        super();
+    }
+}
+
+playdate.update = () => {
+    printTable(new A());
+    printTable(new B());
+};

--- a/libs/cli/src/commands/TranspileCommand/fn/_tests/test-static/tsconfig.json
+++ b/libs/cli/src/commands/TranspileCommand/fn/_tests/test-static/tsconfig.json
@@ -1,0 +1,21 @@
+{
+    "compilerOptions": {
+        "outDir": "Source",
+        "strict": true,
+        "skipLibCheck": true,
+        "baseUrl": "./",
+        "paths": {
+            "@/*": [
+                "src/*"
+            ]
+        },
+        "target": "esnext",
+        "module": "esnext"
+    },
+    "files": [
+        "../../../../../../../types/types/latest.d.ts"
+    ],
+    "include": [
+        "src/**/*.ts"
+    ]
+}

--- a/libs/cli/src/commands/TranspileCommand/fn/_tests/transpile.spec.ts
+++ b/libs/cli/src/commands/TranspileCommand/fn/_tests/transpile.spec.ts
@@ -73,4 +73,19 @@ describe('transpile', () => {
             });
         });
     });
+
+
+    describe('static', () => {
+        const { result, transformedLua } = runTranspilation('static');
+
+        it('should transpile without errors', () => {
+            expect(result.diagnostics).toEqual([]);
+        });
+
+        it('should set static field on class', () => {
+            expect(transformedLua).toContain(
+                'A.staticField = "staticField"'
+            );
+        });
+    })
 });


### PR DESCRIPTION
### Tested with:
```ts
class MyClass {
    static myField = 1;
    constructor() {
    }
}
```
### Before: 
```lua
class("MyClass").extends(Object)
MyClass.init = function(self)
end
```
### After:
```lua
class("MyClass").extends(Object)
MyClass.myField = 1
MyClass.init = function(self)
end
```

Resolves #44 